### PR TITLE
Altered prestige to treat columns with a value of nil as an empty array.

### DIFF
--- a/lib/prestige/result.ex
+++ b/lib/prestige/result.ex
@@ -43,6 +43,12 @@ defmodule Prestige.Result do
     |> Map.new()
   end
 
+  defp transform_column(%{schema: %{"rawType" => "array"}, value: nil} = column) do
+    column
+    |> Map.update(:value, [], fn _ -> [] end)
+    |> transform_column()
+  end
+
   defp transform_column(%{
          name: name,
          schema: %{"rawType" => "array", "typeArguments" => [type_argument]},

--- a/test/array_test.exs
+++ b/test/array_test.exs
@@ -27,6 +27,37 @@ defmodule Prestige.ArrayTest do
     assert expected == actual
   end
 
+  test "null array type fields are treated as empty arrays", %{bypass: bypass} do
+    body = %{
+      "data" => [[2, nil]],
+      "columns" => [
+        %{
+          "name" => "id",
+          "type" => "bigint",
+          "typeSignature" => %{
+            "arguments" => [],
+            "literalArguments" => [],
+            "rawType" => "bigint",
+            "typeArguments" => []
+          }
+        },
+        %{
+          "name" => "stuff",
+          "type" => "array(row(name varchar,color varchar))",
+          "typeSignature" => %{
+            "arguments" => [],
+            "literalArguments" => [],
+            "rawType" => "array",
+            "typeArguments" => []
+          }
+        }
+      ]
+    }
+
+    result = Prestige.Result.transform({:ok, %Tesla.Env{status: 200, body: body}}, true)
+    assert result == {[%{"id" => 2, "stuff" => []}], %{next_uri: nil, rows_as_maps: true}}
+  end
+
   defp presto_response(conn) do
     body = %{
       "addedPreparedStatements" => %{},


### PR DESCRIPTION
smartcolumbusos/discovery#36

co-authored-by: Cameron Marsh <cmarsh@pillartechnology.com>